### PR TITLE
add #include <map> to resolve compilation issues on Ubuntu 18.10 

### DIFF
--- a/HFP-growth/FPTree.hpp
+++ b/HFP-growth/FPTree.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <vector>
+#include <map>
 #include <memory>
 #include <utility>
 #include <type_traits>

--- a/IFP-growth/FPTree.cpp
+++ b/IFP-growth/FPTree.cpp
@@ -1,7 +1,7 @@
 #include <atomic>
 
 #include "FPTree.hpp"
-
+#include <map>
 #include <gimlet/json_parser.hpp>
 #include <gimlet/data_iterator.hpp>
 

--- a/IFP-growth/FPTree.hpp
+++ b/IFP-growth/FPTree.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <vector>
+#include <map>
 #include <memory>
 #include <utility>
 #include <type_traits>


### PR DESCRIPTION
(using the process described in README.md, using g++-7)